### PR TITLE
Add asynchronous test examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,36 @@ The code sets up a basic Express server with a few routes and some tests which c
 npm test
 ```
 
+## Test Examples
+
+### Asynchronous functions and promises
+
+Some examples of how to test asynchronous functions and promises, including some tips and tricks and gotchas. See code examples [here](https://github.com/MarcL/js-unit-testing-examples/test/examples/asychronous.test.js).
+
+#### Asynchronous function
+- Timeout because `done` callback isn't called when function succeeds
+- Passing test but slow because timer isn't stubbed
+- Passing test and fast because timer is stubbed
+- Timeout because `done` callback isn't called when function throws an error
+- Passing test to call `done` callback when function throws an error
+
+#### Promise : resolving
+- Test passes incorrectly because Promise isn't returned
+- Passing test because promise is returned
+- Passing test because `done` callback is called after resolution
+- Passing test because `done` callback is called after resolution using `chai-as-promised` syntax
+
+#### Promise : rejecting
+- Test passes incorrectly because Promise isn't returned
+- Failing test because rejected Promise error isn't caught
+- Passing test because Promise is returned and rejection is caught
+- Passing test because Promise rejection is caught and `done` callback is called
+- Passing test because Promise rejection is caught and `done` callback is called using `chai-as-promised` syntax
+
+#### Slow tests
+- Passing test but is slow due to Promise function in chain taking a long time
+- Passing test and much faster as longer function is now stubbed to execute immediately
+
 ## License
 
 See [LICENSE](LICENSE)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm test
 
 ### Asynchronous functions and promises
 
-Some examples of how to test asynchronous functions and promises, including some tips and tricks and gotchas. See code examples [here](https://github.com/MarcL/js-unit-testing-examples/test/examples/asychronous.test.js).
+Some examples of how to test asynchronous functions and promises, including some tips and tricks and gotchas. See code examples [here](test/examples/asychronous.test.js).
 
 #### Asynchronous function
 - Timeout because `done` callback isn't called when function succeeds

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ The code sets up a basic Express server with a few routes and some tests which c
 npm test
 ```
 
-## Test Examples
+## JavaScript Tests
+
+Take a look in the `test` directory to see all of the test code. There are lots of examples of different types of tests and how to create them.
 
 ### Asynchronous functions and promises
 
-Some examples of how to test asynchronous functions and promises, including some tips and tricks and gotchas. See code examples [here](test/examples/asychronous.test.js).
+Some examples of how to test asynchronous functions and promises, including some tips and tricks and gotchas.
 
 #### Asynchronous function
 - Timeout because `done` callback isn't called when function succeeds

--- a/test/examples/asynchronous.test.js
+++ b/test/examples/asynchronous.test.js
@@ -1,0 +1,186 @@
+// All tests that are skipped are done so because otherwise I won't allow
+// them to be pushed to a git repo due to running the tests on the prepush rule in package.json
+describe('Example asynchronous JavaScript tests', () => {
+    describe('while testing asynchronous function', () => {
+        // eslint-disable-next-line no-unused-vars
+        it.skip('[FAILING TEST] should timeout because the done callback is not called', (done) => {
+            setTimeout(() => {
+                expect(true).to.be.true;
+            }, 1000);
+        });
+
+        it('[PASSING BUT BAD TEST] should pass because the done callback is called but takes too long (~1000ms) to run', (done) => {
+            setTimeout(() => {
+                expect(true).to.be.true;
+                done();
+            }, 1000);
+        });
+
+        describe('better asynchronous test that stubs timer', () => {
+            let fakeClock;
+
+            beforeEach(() => {
+                fakeClock = sinon.useFakeTimers();
+            });
+
+            afterEach(() => {
+                fakeClock.restore();
+            });
+
+            it('[PASSING AND BETTER TEST] should stub clock to allow quick resolution of asynchronous function', (done) => {
+                setTimeout(() => {
+                    expect(true).to.be.true;
+                    done();
+                }, 1000);
+
+                fakeClock.tick(1000);
+            });
+        });
+
+        // eslint-disable-next-line no-unused-vars
+        it.skip('[FAILING TEST] should timeout because the done callback is not called when function has errors', (done) => {
+            setTimeout(() => {
+                throw new Error('Something has gone wrong');
+
+                // eslint-disable-next-line no-unreachable
+                expect(true).to.be.true;
+            }, 10);
+        });
+
+        it('[PASSING TEST] should call the done callback when error occurs', (done) => {
+            setTimeout(() => {
+                try {
+                    throw new Error('Something has gone wrong');
+
+                } catch(error) {
+                    expect(true).to.be.true;
+                    done();
+                }
+            }, 10);
+        });
+    });
+
+    describe('while testing Promises', () => {
+        describe('when Promise resolves', () => {
+            it('[INCORRECT TEST] should pass but it never checks expectation', () => {
+                const givenString = 'finished';
+                Promise.resolve(givenString)
+                    .then((data) => {
+                        expect(data).to.equal(givenString);
+                    });
+            });
+
+            it('[PASSING TEST] should pass because it returns the promise', () => {
+                const givenString = 'finished';
+                return Promise.resolve(givenString)
+                    .then((data) => {
+                        expect(data).to.equal(givenString);
+                    });
+            });
+
+            it('[PASSING TEST] should pass because it calls the done callback when Promise has resolved', (done) => {
+                const givenString = 'finished';
+                Promise.resolve(givenString)
+                    .then((data) => {
+                        expect(data).to.equal(givenString);
+                        done();
+                    });
+            });
+
+            it('[PASSING TEST] should pass because it calls the done callback when Promise has resolved using chai-as-promised syntax', (done) => {
+                const givenString = 'finished';
+                Promise.resolve(givenString)
+                    .then((data) => {
+                        expect(data).to.equal(givenString);
+                    })
+                    .should.notify(done);
+            });
+        });
+
+        describe('when Promise rejects', () => {
+            it('[FAILING TEST] should pass because it does not return the Promise', () => {
+                const givenString = 'error';
+                Promise.reject(givenString);
+            });
+
+            it.skip('[FAILING TEST] should fail because it does not catch the rejection when returning the Promise', () => {
+                const givenString = 'error';
+                return Promise.reject(givenString);
+            });
+
+            it('[PASSING TEST] should pass because it catches the rejection and returns the Promise', () => {
+                const givenString = 'error';
+                return Promise.reject(givenString)
+                    .catch((error) => {
+                        expect(error).to.equal(givenString);
+                    });
+            });
+
+            it('[PASSING TEST] should pass because it catches the rejection and calls the done callback', (done) => {
+                const givenString = 'error';
+                Promise.reject(givenString)
+                    .catch((error) => {
+                        expect(error).to.equal(givenString);
+                        done();
+                    });
+            });
+
+            it('[PASSING TEST] should pass because it catches the rejection and calls the done callback using chai-as-promised syntax', (done) => {
+                const givenString = 'error';
+                Promise.reject(givenString)
+                    .catch((error) => {
+                        expect(error).to.equal(givenString);
+                    })
+                    .should.notify(done);
+            });
+        });
+    });
+
+    describe('while testing function with internal function which takes some time', () => {
+        const moduleUnderTest = {
+            longFunction(data) {
+                return new Promise((resolve) => {
+                    setTimeout(() => {
+                        resolve(data);
+                    }, 1000);
+                });
+            }
+        };
+
+        it('[BAD TEST] should pass but takes too long (~1000ms) to run', () => {
+            const givenString = 'finished';
+
+            return Promise.resolve(givenString)
+                .then(data => moduleUnderTest.longFunction(data))
+                .then((data) => {
+                    expect(data).to.equal(givenString);
+                });
+        });
+
+        describe('when long function is stubbed to execute immediately', () => {
+            let stubLongFunction;
+
+            beforeEach(() => {
+                stubLongFunction = sinon.stub(moduleUnderTest, 'longFunction');
+            });
+
+            afterEach(() => {
+                stubLongFunction.restore();
+            });
+
+            it('[FIXED TEST] should pass and long function will execute immediately', () => {
+                const givenString = 'finished';
+
+                // Stub our long function so it returns immediately
+                // with the data we expect it to return
+                stubLongFunction.resolves(givenString);
+
+                return Promise.resolve(givenString)
+                    .then(data => moduleUnderTest.longFunction(data))
+                    .then((data) => {
+                        expect(data).to.equal(givenString);
+                    });
+            });
+        });
+    });
+});


### PR DESCRIPTION
I'm writing a blog post about tips, tricks and gotchas when you're testing asynchronous functions so I thought it would be good to add some examples using Mocha as it has great support for asynchronous testing. Test examples include:

## Asynchronous function
- Timeout because `done` callback isn't called when function succeeds
- Passing test but slow because timer isn't stubbed
- Passing test and fast because timer is stubbed
- Timeout because `done` callback isn't called when function throws an error
- Passing test to call `done` callback when function throws an error

## Promise : resolving
- Test passes incorrectly because Promise isn't returned
- Passing test because promise is returned
- Passing test because `done` callback is called after resolution
- Passing test because `done` callback is called after resolution using `chai-as-promised` syntax

## Promise : rejecting
- Test passes incorrectly because Promise isn't returned
- Failing test because rejected Promise error isn't caught
- Passing test because Promise is returned and rejection is caught
- Passing test because Promise rejection is caught and `done` callback is called
- Passing test because Promise rejection is caught and `done` callback is called using `chai-as-promised` syntax

## Slow tests
- Passing test but is slow due to Promise function in chain taking a long time
- Passing test and much faster as longer function is now stubbed to execute immediately